### PR TITLE
Claude code design enhancements test

### DIFF
--- a/backup_database.sh
+++ b/backup_database.sh
@@ -56,7 +56,7 @@
         fi
         if [ -f $DUMP_FILE ]; then
         # Upload Dump File to Minio Bucket
-        mc config host add myminio $MINIO_HOST $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
+        mc alias set myminio $MINIO_HOST $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
         ls -alh $DUMP_FILE
         file $DUMP_FILE
         stat $DUMP_FILE
@@ -80,7 +80,7 @@
         if [ $? -eq 0 ]; then
         echo "Dump file uploaded to Minio bucket: $MINIO_BUCKET"
         mv $DUMP_FILE_TAR $TMP_DIR/wsl_{{ .Values.targetEnv }}_db_dump_latest.tar.gz
-        $DUMP_FILE_TAR = $TMP_DIR/wsl_{{ .Values.targetEnv }}_db_dump_latest.tar.gz
+        DUMP_FILE_TAR=$TMP_DIR/wsl_{{ .Values.targetEnv }}_db_dump_latest.tar.gz
         if [ -f $DUMP_FILE_TAR ]; then
             echo "Dump file renamed to db_dump_latest.tar.gz"
             mc cp $DUMP_FILE_TAR myminio/$MINIO_BUCKET/hourly/                # Copy the latest dump to hourly folder

--- a/devops/webimpetus-chart/templates/configmaps.yaml
+++ b/devops/webimpetus-chart/templates/configmaps.yaml
@@ -203,7 +203,8 @@ data:
         fi
         if [ -f $DUMP_FILE ]; then
         # Upload Dump File to Minio Bucket
-        mc config host add myminio $MINIO_HOST $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
+        # not working mc config host add myminio $MINIO_HOST $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
+        mc alias set myminio $MINIO_HOST $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
         ls -alh $DUMP_FILE
         file $DUMP_FILE
         stat $DUMP_FILE


### PR DESCRIPTION
⏺ Fixed the errors in backup_database.sh:

  1. Line 59: Changed mc config host add to mc alias set
    - The correct MinIO client command is mc alias set not mc config
  2. Line 83: Fixed bash variable assignment syntax
    - Changed $DUMP_FILE_TAR = ... to DUMP_FILE_TAR=...
    - Removed the $ and space around = for proper variable assignment

  The script should now work correctly with the MinIO client commands.
