### PR TITLE
Fix: Remove Kint\Renderer\Renderer dependency from Kint config

### DIFF
--- a/ci4/app/Config/Kint.php
+++ b/ci4/app/Config/Kint.php
@@ -3,7 +3,6 @@
 namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
-use Kint\Renderer\Renderer;
 
 /**
  * --------------------------------------------------------------------------
@@ -40,7 +39,7 @@ class Kint extends BaseConfig
 
     public $richFolder = false;
 
-    public $richSort = Renderer::SORT_FULL;
+    public $richSort = 0; // Renderer::SORT_FULL equivalent
 
     public $richObjectPlugins;
 


### PR DESCRIPTION
- Kint library is not installed in production environment
- Removed "use Kint\Renderer\Renderer" import
- Changed Renderer::SORT_FULL to numeric value 0
- Fixes "Class 'Kint\Renderer\Renderer' not found" error